### PR TITLE
Replace FlyCI runners with GitHub runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: flyci-macos-14-m2
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR replaces the use of FlyCI macOS runners with GitHub ones since FlyCI macOS runners will be discontinued effective Sep 30, 2024. 

[Read more about the discontinuation of the FlyCI macOS runners](https://flyci.net/blog/flyci-discontinue-macos-runners?utm_source=site_link&utm_medium=github&utm_campaign=discontinue-runners).